### PR TITLE
make rasmlib compatible with current version of xarray

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,7 @@ before_install:
 
 # Make Conda environment and install packages
 install: 
-  - conda create --yes --name=test-environment python=$TRAVIS_PYTHON_VERSION matplotlib basemap pandas numpy netCDF4 xarray -c conda-forge
-  - pip install nco 
+  - conda create --yes --name=test-environment python=$TRAVIS_PYTHON_VERSION matplotlib basemap pandas numpy netCDF4 xarray nco -c conda-forge
   - source activate test-environment
   - python setup.py install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,4 +25,3 @@ install:
 # command to run tests
 script:
   - rasm_post_process -h
-  - py.test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,35 +1,26 @@
 language: python
 
 python:
-  - "2.6"
-  - "2.7"
-  - "3.3"
+  - "3.6"
 
+# Setup anaconda
 before_install:
   - sudo apt-get update
   - sudo apt-get install libnetcdf-dev nco
-
-install:
-  # Get anaconda
-  - if [[ "$TRAVIS_PYTHON_VERSION" == "3.3" ]]; then
-      wget http://repo.continuum.io/anaconda3/Anaconda3-2.1.0-Linux-x86_64.sh -O anaconda.sh;
-    else
-      wget http://09c8d0b2229f813c1b93-c95ac804525aac4b6dba79b00b39d1d3.r79.cf1.rackcdn.com/Anaconda-2.1.0-Linux-x86_64.sh -O anaconda.sh;
-    fi
-  - bash anaconda.sh -b -p $HOME/anaconda
-  - export PATH="$HOME/anaconda/bin:$PATH"
+  - wget http://repo.continuum.io/miniconda/Miniconda3-3.16.0-Linux-x86_64.sh -O miniconda.sh;
+  - bash anaconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   # Useful for debugging any issues with conda
   - conda info -a
 
-  # Make Conda test environment
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
+# Make Conda environment and install packages
+install: 
+  - conda create --yes --name=test-environment python=$TRAVIS_PYTHON_VERSION matplotlib basemap pandas numpy netCDF4 xarray -c conda-forge
+  - pip install nco 
   - source activate test-environment
-  - conda install matplotlib basemap pandas numpy netCDF4
-  - conda update pandas netcdf4
-  - pip install xray nco
   - python setup.py install
 
 # command to run tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ before_install:
 
 # Make Conda environment and install packages
 install: 
-  - conda create --yes --name=test-environment python=$TRAVIS_PYTHON_VERSION matplotlib basemap pandas numpy netcdf4 xarray pynco -c conda-forge
-  - source activate test-environment
+  - conda create --yes --name=test python=$TRAVIS_PYTHON_VERSION matplotlib basemap pandas numpy netcdf4 xarray pynco pytest -c conda-forge
+  - source activate test
   - python setup.py install
 
 # command to run tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
 
 # Make Conda environment and install packages
 install: 
-  - conda create --yes --name=test-environment python=$TRAVIS_PYTHON_VERSION matplotlib basemap pandas numpy netCDF4 xarray nco pynco -c conda-forge
+  - conda create --yes --name=test-environment python=$TRAVIS_PYTHON_VERSION matplotlib basemap pandas numpy netcdf4 xarray pynco -c conda-forge
   - source activate test-environment
   - python setup.py install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
 
 # Make Conda environment and install packages
 install: 
-  - conda create --yes --name=test-environment python=$TRAVIS_PYTHON_VERSION matplotlib basemap pandas numpy netCDF4 xarray nco -c conda-forge
+  - conda create --yes --name=test-environment python=$TRAVIS_PYTHON_VERSION matplotlib basemap pandas numpy netCDF4 xarray nco pynco -c conda-forge
   - source activate test-environment
   - python setup.py install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
   - sudo apt-get update
   - sudo apt-get install libnetcdf-dev nco
   - wget http://repo.continuum.io/miniconda/Miniconda3-3.16.0-Linux-x86_64.sh -O miniconda.sh;
-  - bash anaconda.sh -b -p $HOME/miniconda
+  - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
   - conda config --set always_yes yes --set changeps1 no

--- a/ci/requirements-2.6.txt
+++ b/ci/requirements-2.6.txt
@@ -1,4 +1,4 @@
-xray
+xarray
 matplotlib
 basemap
 pandas

--- a/ci/requirements-2.7.txt
+++ b/ci/requirements-2.7.txt
@@ -1,4 +1,4 @@
-xray
+xarray
 matplotlib
 basemap
 pandas

--- a/ci/requirements-3.3.txt
+++ b/ci/requirements-3.3.txt
@@ -1,4 +1,4 @@
-xray
+xarray
 matplotlib
 basemap
 pandas

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -14,7 +14,7 @@ analysis module dependencies:
   - numpy_ : Fundamental package needed for scientific computing with Python.
   - scipy_: Open-source software for mathematics, science, and engineering.
   - pandas_ : Flexible and powerful data analysis / manipulation library for Python.
-  - xray_ :  N-D labeled arrays and datasets in Python.
+  - xarray_ :  N-D labeled arrays and datasets in Python.
   - matplotlib basemap_ : The matplotlib basemap toolkit is a library for plotting 2D data on maps in Python.
   - seaborn_ : Statistical data visualization using matplotlib.
 
@@ -34,7 +34,7 @@ To install `rasmlib`, use `setuptools`:
 .. _numpy: http://www.numpy.org/
 .. _scipy: http://docs.scipy.org/doc/
 .. _pandas: http://pandas.pydata.org/
-.. _xray: http://xray.readthedocs.org/en/stable/index.html
+.. _xarray: http://xray.readthedocs.org/en/stable/index.html
 .. _basemap: http://matplotlib.org/basemap/index.html
 .. _seaborn: http://web.stanford.edu/~mwaskom/software/seaborn/index.html
 .. _nco: http://nco.sourceforge.net/

--- a/rasmlib/analysis/climatology.py
+++ b/rasmlib/analysis/climatology.py
@@ -2,30 +2,30 @@
 module to support calculating climatolical statistics
 """
 
-import xray
+import xarray as xr
 import numpy as np
 from ..calendar import get_dpm
 
 
 def season_mean(ds, calendar='standard'):
     """
-    Calculate the seasonal mean from a xray Dataset of monthly means. Weight
+    Calculate the seasonal mean from an xarray Dataset of monthly means. Weight
     the means by the number of days in each month.
 
     Parameters
     ----------
-    ds : xray.Dataset
+    ds : xarray.Dataset
         Monthly frequency Pandas DatetimeIndex.
     calendar : {'standard', 'gregorian', 'proleptic_gregorian', 'julian'}
         netCDF calendar with leap years.
 
     Returns
     ----------
-    seasonal_mean : xray.Dataset
+    seasonal_mean : xarray.Dataset
         Dataset representing the seasonal mean of `ds`.
     """
     # Make a DataArray with the number of days in each month, size = len(time)
-    month_length = xray.DataArray(get_dpm(ds.time.to_index(),
+    month_length = xr.DataArray(get_dpm(ds.time.to_index(),
                                   calendar=calendar),
                                   coords=[ds.time],
                                   name='month_length')
@@ -43,23 +43,23 @@ def season_mean(ds, calendar='standard'):
 
 def annual_mean(ds, calendar='standard'):
     """
-    Calculate the annual mean from a xray Dataset of monthly means. Weight
+    Calculate the annual mean from an xarray Dataset of monthly means. Weight
     the means by the number of days in each month.
 
     Parameters
     ----------
-    ds : xray.Dataset
+    ds : xarray.Dataset
         Monthly frequency Pandas DatetimeIndex.
     calendar : {'standard', 'gregorian', 'proleptic_gregorian', 'julian'}
         netCDF calendar with leap years.
 
     Returns
     ----------
-    seasonal_mean : xray.Dataset
+    seasonal_mean : xarray.Dataset
         Dataset representing the annual mean of `ds`.
     """
     # Make a DataArray with the number of days in each month, size = len(time)
-    month_length = xray.DataArray(get_dpm(ds.time.to_index(),
+    month_length = xr.DataArray(get_dpm(ds.time.to_index(),
                                   calendar=calendar),
                                   coords=[ds.time],
                                   name='month_length')

--- a/rasmlib/analysis/plotting.py
+++ b/rasmlib/analysis/plotting.py
@@ -235,7 +235,7 @@ def plot4_seasons(lons, lats, pannels, variables,
     ----------
     pannels : dict
         Dictionary of data pannels with a structure of
-        {pannel_number: xray.Dataset} to be accessed as
+        {pannel_number: xarray.Dataset} to be accessed as
         [pannel_number][variable][season, y, x].
     variables: str or list like
         Name of variable(s) to plot.

--- a/rasmlib/io.py
+++ b/rasmlib/io.py
@@ -1,7 +1,7 @@
 """io.py"""
 import os
 from collections import OrderedDict
-import xray
+import xarray as xr
 try:
     from ConfigParser import SafeConfigParser
 except ImportError:
@@ -166,7 +166,7 @@ def make_tarfile(output_filename, source_dir, mode="w:gz"):
 
 def get_datasets(names, files, variables, analysis_vars, timestep):
     """
-    Parse the files and variables namelists and load the files into xray
+    Parse the files and variables namelists and load the files into xarray
     objects.
     """
     datasets = OrderedDict()
@@ -190,7 +190,7 @@ def get_datasets(names, files, variables, analysis_vars, timestep):
         dataset_class = f['DATASET_CLASS'].values[0]
 
         # read the dataset
-        ds = xray.open_dataset(file_path)
+        ds = xr.open_dataset(file_path)
 
         # adjust units and var names
         for var in analysis_vars:
@@ -223,7 +223,7 @@ def get_datasets(names, files, variables, analysis_vars, timestep):
 
 
 def read_domain(filepath):
-    """read a CESM domain file and return a xray dataset
+    """read a CESM domain file and return an xarray dataset
 
     Parameters
     ----------
@@ -232,13 +232,13 @@ def read_domain(filepath):
 
     Returns
     ----------
-    domain : xray.Dataset
+    domain : xarray.Dataset
         Dataset with domain variables.
     """
 
     re = 6.37122e6
 
-    domain = xray.open_dataset(filepath)
+    domain = xr.open_dataset(filepath)
     domain['xc'] = domain['xc'].rename('lon')
     domain['yc'] = domain['yc'].rename('lat')
     domain['area'] *= re * re  # area in m2

--- a/readme.md
+++ b/readme.md
@@ -29,4 +29,4 @@ This program is distributed in the hope that it will be useful, but WITHOUT ANY 
 
 You should have received a copy of the GNU General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-rasmlib includes portions of pandas, matplotlib, xray, netCDF, and other projects. See those projects for licenses specific use policies related to their licesnses.
+rasmlib includes portions of pandas, matplotlib, xarray, netCDF, and other projects. See those projects for licenses specific use policies related to their licesnses.

--- a/scripts/rasm_analysis
+++ b/scripts/rasm_analysis
@@ -53,7 +53,7 @@ for analysis_name, analysis_dict in config.iteritems():
     print("Using plugin {0}".format(plugin_name))
 
     # ----------------------------------------------------------------------- #
-    # Get dictionary of xray datasets
+    # Get dictionary of xarray datasets
     case_names = analysis_dict.pop('CASE_NAMES')
     if not isinstance(case_names, list):
         case_names = [case_names]


### PR DESCRIPTION
This PR updates `xray` to `xarray` in rasmlib. 